### PR TITLE
Export default in index.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,3 +2,4 @@ import EventTracker from 'eventTracker';
 import ConsoleTracker from 'tracker/consoleTracker';
 import HttpTracker from 'tracker/httpTracker';
 export { EventTracker, ConsoleTracker, HttpTracker };
+export default EventTracker;


### PR DESCRIPTION
Same as before. But this time against the ```rename-lib``` branch.