### PR TITLE
Make click tracking work with SVG nodes

### DIFF
--- a/public/static/index.html
+++ b/public/static/index.html
@@ -28,6 +28,7 @@
 <button onclick="track();">Track custom</button>
 <button onclick="filteredTrack();">Should be filtered</button>
 <button onclick="changeUser();">Change user</button>
+<svg viewBox="0 0 50 20" width="50" height="20"><text x="0" y="20">SVG</text></svg>
 
 <script language="JavaScript">
   function track() {

--- a/public/static/index.html
+++ b/public/static/index.html
@@ -8,7 +8,7 @@
   <meta name="description" content="Test page">
 
   <!--<link rel="stylesheet" href="css/styles.css?v=1.0">-->
-  <script src="../../dist/et.js"></script>
+  <script src="../../dist/event-tracker.js"></script>
   <script src="./main.js"></script>
 
 </head>

--- a/public/static/main.js
+++ b/public/static/main.js
@@ -8,7 +8,7 @@ const eventTracker = new EventTracker.EventTracker({
       EventTracker.Filters.BotFilter
     ]
   }),
-  trackClicks: false,
+  trackClicks: true,
   trackActiveTime: true,
   trackHashChanges: true,
   trackElementClicks: true,

--- a/public/static/second.html
+++ b/public/static/second.html
@@ -8,7 +8,7 @@
   <meta name="description" content="Test page">
 
   <!--<link rel="stylesheet" href="css/styles.css?v=1.0">-->
-  <script src="../../dist/et.js"></script>
+  <script src="../../dist/event-tracker.js"></script>
   <script src="./main.js"></script>
 
 </head>

--- a/src/domUtil.js
+++ b/src/domUtil.js
@@ -111,7 +111,7 @@ DomUtil.genCssSelector = node => {
 
   while (node !== document.body) {
     let id = node.id;
-    let classes = node.className.split(' ').join('.');
+    let classes = (node.getAttribute('class') || '').split(' ').join('.');
     const tagName = node.nodeName.toLowerCase();
 
     if (id && id !== '') id = `#${id}`;


### PR DESCRIPTION
The `className` property on SVGElements can be an `SVGAnimatedString`,
so this  would throw an error "...className.split() is not a function" when
clicking an SVG on a page with EventTracker.

See https://developer.mozilla.org/en-US/docs/Web/API/Element/className#Notes